### PR TITLE
Add reject button to admin/pet-applicaiton each pet with tests

### DIFF
--- a/app/controllers/admin_applications_controller.rb
+++ b/app/controllers/admin_applications_controller.rb
@@ -7,8 +7,10 @@ class AdminApplicationsController < ApplicationController
     pet_update = PetApplication.find(params[:application_pet_id])
     if params[:value] == "Approved"
       pet_update.update(status: "Approved")
+      flash[:notice] = "This pet has been APPROVED for adoption. Congrats!"
     else params[:value] == "Rejected"
       pet_update.update(status: "Rejected")
+      flash[:notice] = "This pet has been REJECTED for adoption. Sorry."
     end
     redirect_to "/admin/applications/#{params[:application_id]}"
   end

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -16,6 +16,7 @@
   <% else %>
     <div class="button-group">
     <%= button_to "Approve", "/admin/applications/#{admin_pet.application.id}/#{admin_pet.id}", method: :patch, data: { turbo: false }, params: { value: "Approved" } %>
+    <%= button_to "Reject", "/admin/applications/#{admin_pet.application.id}/#{admin_pet.id}", method: :patch, data: { turbo: false }, params: { value: "Rejected" } %>
     </div>
     <% end %>
   </div>

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -46,5 +46,56 @@ RSpec.describe "the admin application show" do
         expect(page).to_not have_content("Approved")
       end
     end
+
+    it "For every pet that the application is for, I see a button to reject the application for that specific pet" do
+      
+      visit "/admin/applications/#{@application_1.id}"
+
+      within("#Bare-y-Manilow") do
+        expect(page).to have_content(@pet_1.name) # Bare-y Manilow
+        expect(page).to have_button("Approve")
+        expect(page).to have_button("Reject")
+      end
+
+      within("#Lobster") do
+        expect(page).to have_content(@pet_2.name) # Lobster
+        expect(page).to have_button("Approve")
+        expect(page).to have_button("Reject")
+      end
+    end
+
+    it "When I click the reject button then I'm taken back to the admin application show page and do not see buttons next to that pet" do
+
+      visit "/admin/applications/#{@application_1.id}"
+      
+      expect(page).to have_current_path("/admin/applications/#{@application_1.id}")
+
+      within("#Bare-y-Manilow") do
+        click_button("Reject")
+        expect(page).to have_content("Rejected")
+        expect(page).to have_current_path("/admin/applications/#{@application_1.id}")
+      end
+
+      within("#Lobster") do
+        expect(page).to_not have_content("Rejected")
+      end
+    end
+
+    it "When I click assignment buttons they update the pet and then vanish from the view page" do
+
+      visit "/admin/applications/#{@application_1.id}"
+      
+      within("#Bare-y-Manilow") do
+        click_button("Reject")
+        expect(page).to have_content("Rejected")
+      end
+      
+      within("#Lobster") do
+        click_button("Approve")
+        expect(page).to have_content("Approved")
+      end
+
+      expect(page).to_not have_css('.button-group')
+    end
   end
 end


### PR DESCRIPTION
## Description

Completes issue #4 
Completes user story 13
Add button to admin/applications/petapplications for each individual pet.  with flash notice
Add tests

## Type of change

- [ ] fix
- [x] feat
- [x] test
- [ ] refactor
- [ ] docs

## Checklist

- [x] code has been self reviewed
- [x] code runs without any errors
- [x] thorough testing has been implemented if adding feature
- [x] all tests pass

### Thanks!
