### PR TITLE
14 approvedrejected pets on one application do not affect other applications

### DIFF
--- a/app/controllers/admin_applications_controller.rb
+++ b/app/controllers/admin_applications_controller.rb
@@ -1,6 +1,6 @@
 class AdminApplicationsController < ApplicationController
   def show
-    @admin_application = Application.find(params[:app_id])
+    @application = Application.find(params[:app_id])
   end
 
   def update

--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -1,12 +1,6 @@
-<h1>Application Details</h1>
-<h3>Name: <%= @admin_application.name %></h3>
-<p>Address Line 1: <%= @admin_application.street %></p>
-<p>Address Line 2: <%= @admin_application.city %>, <%= @admin_application.state %> <%= @admin_application.zip_code %></p>
-<p>Status: <%= @admin_application.status %></p>
+<%= render partial: "layouts/application_details" %>
 
-<p>Description: <%= @admin_application.description %></p>
-
-<% @admin_application.pet_applications.each do |admin_pet| %>
+<% @application.pet_applications.each do |admin_pet| %>
   <div id="<%= admin_pet.pet.name %>">
   <p><%= admin_pet.pet.name %></p>
   <% if admin_pet.status == "Approved" %>
@@ -22,4 +16,4 @@
   </div>
 <% end %>
 
-<p>Adoption Status: <%= @admin_application.status %></p>
+<p>Adoption Status: <%= @application.status %></p>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -1,8 +1,4 @@
-<h1>Application Details</h1>
-<h3>Name: <%= @application.name %></h3>
-<p>Address Line 1: <%= @application.street %></p>
-<p>Address Line 2: <%= @application.city %>, <%= @application.state %> <%= @application.zip_code %></p>
-<p>Status: <%= @application.status %></p>
+<%= render partial: "layouts/application_details" %>
 
 <p>Description: <%= @application.description %></p>
 

--- a/app/views/layouts/_application_details.html.erb
+++ b/app/views/layouts/_application_details.html.erb
@@ -1,0 +1,6 @@
+<h1>Application Details</h1>
+<h3>Name: <%= @application.name %></h3>
+<p>Address Line 1: <%= @application.street %></p>
+<p>Address Line 2: <%= @application.city %>, <%= @application.state %> <%= @application.zip_code %></p>
+<p>Status: <%= @application.status %></p>
+<p>Description: <%= @application.description %></p>

--- a/app/views/pets/_pet_form.html.erb
+++ b/app/views/pets/_pet_form.html.erb
@@ -1,0 +1,15 @@
+<%= form_with url: path, method: method, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :breed %>
+  <%= f.text_field :breed %>
+
+  <%= f.label :age %>
+  <%= f.number_field :age %>
+
+  <%= f.label :adoptable %>
+  <%= f.check_box adopt %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/pets/edit.html.erb
+++ b/app/views/pets/edit.html.erb
@@ -1,16 +1,8 @@
 <h1>Edit Pet</h1>
-<%= form_with url: "/pets/#{@pet.id}", method: :patch, local: true do |f| %>
-  <%= f.label :name %>
-  <%= f.text_field :name %>
 
-  <%= f.label :breed %>
-  <%= f.text_field :breed %>
+<%= render partial: 'pet_form', locals: {
+  path: "/pets/#{@pet.id}",
+  method: :patch,
+  adopt: :adoptable
+} %>
 
-  <%= f.label :adoptable %>
-  <%= f.check_box :adoptable %>
-
-  <%= f.label :age %>
-  <%= f.number_field :age %>
-
-  <%= f.submit %>
-<% end %>

--- a/app/views/pets/new.html.erb
+++ b/app/views/pets/new.html.erb
@@ -1,16 +1,7 @@
 <h1>New Pet</h1>
-<%= form_with url: "/shelters/#{@shelter.id}/pets", method: :post, local: true do |f| %>
-  <%= f.label :name %>
-  <%= f.text_field :name %>
 
-  <%= f.label :breed %>
-  <%= f.text_field :breed %>
-
-  <%= f.label :age %>
-  <%= f.number_field :age %>
-
-  <%= f.label :adoptable %>
-  <%= f.check_box :adoptable, value: true %>
-
-  <%= f.submit %>
-<% end %>
+<%= render partial: 'pet_form', locals: {
+  path: "/shelters/#{@shelter.id}/pets",
+  method: :post,
+  adopt: :adoptable, value: true
+} %>

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "the admin application show" do
     @application_2 = Application.create!(name: "Quagmire", street: "300 Crest Lane", city: "Lowell", state: "NY", zip_code: "12345", description: "Giggity", status: "Pending")
     @apply_1 = PetApplication.create!(application_id: @application_1.id, pet_id: @pet_1.id, status: "Pending")
     @apply_2 = PetApplication.create!(application_id: @application_1.id, pet_id: @pet_2.id, status: "Pending")
+    @apply_3 = PetApplication.create!(application_id: @application_2.id, pet_id: @pet_1.id, status: "Pending")
+    @apply_4 = PetApplication.create!(application_id: @application_2.id, pet_id: @pet_2.id, status: "Pending")
   end
 
   describe "When I visit an admin application show page ('/admin/applications/:id')" do
@@ -97,5 +99,40 @@ RSpec.describe "the admin application show" do
 
       expect(page).to_not have_css('.button-group')
     end
+  end
+
+  describe "When there are two applications in the system for the same pets" do
+    describe "When I visit the admin application show page for one of the applications" do
+      it "I approve or reject a pet for this application and it does not affect the same pets on other applications" do
+
+        visit "/admin/applications/#{@application_1.id}"
+
+        within("#Bare-y-Manilow") do
+          click_button("Reject")
+          expect(page).to have_content("Rejected")
+        end
+        
+        within("#Lobster") do
+          click_button("Approve")
+          expect(page).to have_content("Approved")
+        end
+        expect(page).to_not have_css('.button-group')
+        visit "/admin/applications/#{@application_2.id}"
+
+        within("#Bare-y-Manilow") do
+          expect(page).to have_content(@pet_1.name) # Bare-y Manilow
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
+        end
+  
+        within("#Lobster") do
+          expect(page).to have_content(@pet_2.name) # Lobster
+          expect(page).to have_button("Approve")
+          expect(page).to have_button("Reject")
+        end
+        expect(page).to have_css('.button-group')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## Description

Completes issue #3  on user story 14
Add test for pets approved/rejected on one application DO NOT affect pets on a different application.
Add partials for new/edit pets and application/admin-application details show pages

## Type of change

- [ ] fix
- [x] feat
- [x] test
- [ ] refactor
- [ ] docs

## Checklist

- [x] code has been self reviewed
- [x] code runs without any errors
- [x] thorough testing has been implemented if adding feature
- [x] all tests pass

### Thanks!
